### PR TITLE
Fix webdav in more recent webdav3.client version

### DIFF
--- a/jupyter_sciencedata/jupyter_sciencedata.py
+++ b/jupyter_sciencedata/jupyter_sciencedata.py
@@ -65,7 +65,7 @@ CheckpointContext = namedtuple('Context', [
 ])
 
 SCIENCEDATA_HEADERS = {}
-SCIENCEDATA_PREFIX = "/files/"
+SCIENCEDATA_PREFIX = "/files"
 if 'HOME_SERVER_HOSTNAME' in os.environ:
     SCIENCEDATA_HOST = os.environ['HOME_SERVER_HOSTNAME']
 else:

--- a/jupyter_sciencedata/jupyter_sciencedata.py
+++ b/jupyter_sciencedata/jupyter_sciencedata.py
@@ -64,17 +64,22 @@ CheckpointContext = namedtuple('Context', [
     'logger'
 ])
 
-SCIENCEDATA_HEADERS = {};
-SCIENCEDATA_PREFIX = "/files/";
-SCIENCEDATA_HOST = "sciencedata";
+SCIENCEDATA_HEADERS = {}
+SCIENCEDATA_PREFIX = "/files/"
+if 'HOME_SERVER_HOSTNAME' in os.environ:
+    SCIENCEDATA_HOST = os.environ['HOME_SERVER_HOSTNAME']
+else:
+    SCIENCEDATA_HOST = "sciencedata"
 
 webdav_options = {
  'webdav_hostname': "https://" + SCIENCEDATA_HOST + SCIENCEDATA_PREFIX,
  'webdav_login': '',
  'webdav_password': '',
- 'verify': False
 }
 webdav_client = Client(webdav_options)
+# If https cannot be used, then webdav_client.verify must be false.
+# It used to be possible to set this in webdav_options, but that was discontinued.
+#webdav_client.verify = False
 
 # As far as I can see from
 # https://github.com/ezhov-evgeny/webdav-client-python-3/blob/871ea5f9b862553465551dd79dd5b6b298e3ff17/webdav3/client.py

--- a/jupyter_sciencedata/jupyter_sciencedata.py
+++ b/jupyter_sciencedata/jupyter_sciencedata.py
@@ -28,8 +28,8 @@ from tornado.web import HTTPError as HTTPServerError
 
 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 
-from notebook.services.contents.checkpoints import Checkpoints, GenericCheckpointsMixin
-from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
+from jupyter_server.services.contents.checkpoints import Checkpoints, GenericCheckpointsMixin
+from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoints
 
 from traitlets.config.configurable import Configurable
 from traitlets import (
@@ -43,7 +43,7 @@ from traitlets import (
 
 import nbformat
 from nbformat.v4 import new_notebook
-from notebook.services.contents.manager import (
+from jupyter_server.services.contents.manager import (
     ContentsManager,
 )
 


### PR DESCRIPTION
This will be necessary when we migrate to the new cluster. Don't accept the PR until then, it'll break in the current production setup.